### PR TITLE
'Fixing' #13

### DIFF
--- a/default.py
+++ b/default.py
@@ -47,6 +47,7 @@ def build_episodes_directory():
     listitem = xbmcgui.ListItem(label = name, iconImage = "", thumbnailImage = "")
     #listitem.setInfo( type = "Video", infoLabels = { "Title": name, "Director": __plugin__, "Studio": __plugin__, "Genre": "Video Blog", "Plot": plot[0], "Episode": "" } )
     if ep_url:
+      ep_url = re.sub('^https://','http://', ep_url)
       u = sys.argv[0] + "?mode=2&url=" + ep_url + "&name=" + name
       xbmcplugin.addDirectoryItem(handle = int(sys.argv[1]), url = u, listitem = listitem, isFolder = False)
       xbmcplugin.addSortMethod( handle = int(sys.argv[ 1 ]), sortMethod = xbmcplugin.SORT_METHOD_NONE )
@@ -83,7 +84,7 @@ def play_video(ep_url):
   except:
     xbmc.executebuiltin( "Dialog.Close(busydialog)" )
     xbmc.executebuiltin('Notification(Error,Something went wrong,2000)')
-    return
+    raise
   xbmc.Player().play(item=url, listitem=listitem)
 
 def get_params():


### PR DESCRIPTION
Heya,

This works around https://github.com/ClumsyXBMC/EEVBlog-Xbmc-Plugin/issues/13 by forcing the urls used to access EEVBlog.com to use http; there appears to be an issue with SNI support in the version of Python/urllib2 used in xbmc and this was the only way around that I could come up with.

I've also made the errors bubble up so the exceptions appear in the `kodi.log` rather than being swallowed

Thanks,
